### PR TITLE
Add admin token handling and user roles

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 BOT_TOKEN = your bot token
 
 TOKENS = pd48vBc#, rF@0Hg7h, qCDIH&^0, EJ6lq00%, 5zKnj4P^, f%Mh^Rx9, EvSfR91#, ZGORYzU$, 1Yw*5rBz, x$fSj^f0, pYIa54K^, 18pQABm!, R2Ds1W^e, 6EY96tq^, s4QBQSN*, ID7scey$, 9hw29dp#, 2V*zw2X6, NKkhNij^, p2pz0o@*, L^t8tNAk, j4MoQjK$, S52W&mN8, &O9W!XZw, Yt*9HVFp, s@AnMkK1, Ergw9my@, &9eN8niP, L6CKDdm@, gZhdZaz#, 4q%*aEyd, uGzfV1g!, YFZD$GZ1, *BknRM&1, R2HJzBV*, PJ0Q&%9K, Ssr2gKt$, TpTv^fi5, m2qmUIO%, rG1zKVk@, nIq&VTU8, 2fNZc6**, DpFL5O!j, fpksi^!3, dwrGY!!6, $qBa%53q, 5xURB7a&, 5Qx&G9Yx, G#c0DefK, o^c46&^u
+
+ADMIN_TOKENS = admin_token1, admin_token2

--- a/handlers/start_handler.py
+++ b/handlers/start_handler.py
@@ -2,18 +2,22 @@ import os
 from telegram import Update
 from telegram.ext import ContextTypes, CommandHandler, ConversationHandler, MessageHandler, filters
 from handlers.menu_handler import build_menu
-from utils.storage import set_user_token
+from utils.storage import set_user_token, set_user_role
 from handlers.personal_handler import personal_info  # Qo'shildi
 
 WAITING_TOKEN = 1
 
-def load_tokens() -> set[str]:
-    raw = os.getenv("TOKENS")
-    return {t.strip() for t in raw.split(",") if t.strip()}
+def load_tokens() -> tuple[set[str], set[str]]:
+    raw_tokens = os.getenv("TOKENS", "")
+    raw_admin_tokens = os.getenv("ADMIN_TOKENS", "")
+    tokens = {t.strip() for t in raw_tokens.split(",") if t.strip()}
+    admin_tokens = {t.strip() for t in raw_admin_tokens.split(",") if t.strip()}
+    return tokens, admin_tokens
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    tokens = load_tokens()
-    if not tokens:
+    tokens, admin_tokens = load_tokens()
+    all_tokens = tokens | admin_tokens
+    if not all_tokens:
         await update.message.reply_text(
             "Configuration error: maybe you don't have any tokens"
         )
@@ -22,10 +26,13 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def check_token(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_input = (update.message.text or "").strip()
-    tokens = load_tokens()
-    
-    if user_input in tokens:
+    tokens, admin_tokens = load_tokens()
+    all_tokens = tokens | admin_tokens
+
+    if user_input in all_tokens:
         set_user_token(update.effective_user.id, user_input)
+        role = "admin" if user_input in admin_tokens else "user"
+        set_user_role(update.effective_user.id, role)
         await update.message.reply_text("Успешная авторизация✅", reply_markup=build_menu())
         # Lichniy kabinet ma'lumotlarini ham yuborish
         await personal_info(update, context)

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -173,6 +173,18 @@ def get_user_token(user_id: int) -> Optional[str]:
     db = _load_db()
     return db.get(str(user_id), {}).get("token")
 
+def set_user_role(user_id: int, role: str) -> None:
+    db = _load_db()
+    key = str(user_id)
+    user = db.get(key, {})
+    user["role"] = role
+    db[key] = user
+    _save_db(db)
+
+def get_user_role(user_id: int) -> str:
+    db = _load_db()
+    return db.get(str(user_id), {}).get("role", "user")
+
 def set_user_limits(user_id: int, limits: Dict[str, Any])-> None:
     db = _load_db()
     key = str(user_id)


### PR DESCRIPTION
## Summary
- Load both regular and admin tokens from the environment
- Store and retrieve a user's role alongside their token
- Record admins' roles during token checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac049fa9e883279b3a8167e39807e4