### PR TITLE
Add admin transaction update handler with role check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,8 @@ from handlers.requisites_handler import add_requisites, requisites_info, manage_
 from handlers.add_requisite_handler import requisites_text_handler
 from handlers.support_handler import support_action
 from handlers.status_handler import send_transaction, status_offline, history_transaction
+from handlers.admin_transactions import start as admin_transactions_start, admin_transactions_text_handler
+from utils.storage import get_user_role
 load_dotenv()
 TOKEN = os.getenv("BOT_TOKEN")
 if TOKEN:
@@ -20,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 async def error_handler(update, context):
     print("ERROR:", context.error)
+
+
+async def admin_update_transaction(update, context):
+    """Start admin transaction update conversation if user is admin."""
+    user_id = update.effective_user.id
+    if get_user_role(user_id) != "admin":
+        await update.message.reply_text("Sizda ruxsat yo'q")
+        return
+    await admin_transactions_start(update, context)
 
 
 
@@ -37,6 +48,7 @@ def main():
     app.add_handler(MessageHandler(filters.TEXT & filters.Regex(r"^🟢 В онлайн: ON$"), send_transaction))
     app.add_handler(MessageHandler(filters.TEXT & filters.Regex(r"^🔴 Отключиться: OFF$"), status_offline))
     app.add_handler(MessageHandler(filters.TEXT & filters.Regex(r"^🧾История операций$"), history_transaction))
+    app.add_handler(MessageHandler(filters.TEXT & filters.Regex(r"^♻️ Транзакцию обновить$"), admin_update_transaction))
     # inline keyboards
     app.add_handler(CallbackQueryHandler(personal_inline_action, pattern=r"^pi:"))
     app.add_handler(CallbackQueryHandler(set_new_limits_action, pattern=r"^set:"))
@@ -45,6 +57,7 @@ def main():
     app.add_handler(CallbackQueryHandler(support_action, pattern=r"^support"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, requisites_text_handler), group=1)
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, limits_text_handler ), group=2)
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, admin_transactions_text_handler ), group=3)
 
     # Fallback debug handler (runs last) to log unmatched messages and help diagnose keyboard issues
     async def _debug_unknown(update, context):
@@ -61,3 +74,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/handlers/admin_transactions.py
+++ b/handlers/admin_transactions.py
@@ -1,0 +1,26 @@
+import json
+from telegram import Update
+from telegram.ext import ContextTypes
+
+JSON_PATH = "data/transaction.json"
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Begin conversation for updating transactions JSON."""
+    context.user_data["await"] = "admin_tx:json"
+    await update.message.reply_text("Yangi transactionlar uchun JSON yuboring:")
+
+
+async def admin_transactions_text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    stage = context.user_data.get("await")
+    if stage != "admin_tx:json":
+        return
+    text = (update.message.text or "").strip()
+    try:
+        data = json.loads(text) if text else []
+    except Exception:
+        await update.message.reply_text("❌ JSON xato. Qayta urinib ko'ring.")
+        return
+    with open(JSON_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    context.user_data.pop("await", None)
+    await update.message.reply_text("✅ Транзакции обновлены")

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -199,3 +199,19 @@ def get_user_status(user_id: int) -> str:
     db = _load_db()
     return db.get(str(user_id), {}).get("status", "offline")
 
+
+def set_user_role(user_id: int, role: str) -> None:
+    """Save a user's role (e.g., 'admin')."""
+    db = _load_db()
+    key = str(user_id)
+    user = db.get(key, {})
+    user["role"] = role
+    db[key] = user
+    _save_db(db)
+
+
+def get_user_role(user_id: int) -> str:
+    """Return user's role, defaults to 'user'."""
+    db = _load_db()
+    return db.get(str(user_id), {}).get("role", "user")
+


### PR DESCRIPTION
## Summary
- Allow admins to update transactions via new "♻️ Транзакцию обновить" menu option
- Persist user roles with new storage helpers
- Implement admin transaction conversation for JSON upload

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac05cc6d0c8327a7b1e0bed4ea1d57